### PR TITLE
fix convert plural form

### DIFF
--- a/scaneo.go
+++ b/scaneo.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/jinzhu/inflection"
 )
 
 const (
@@ -367,8 +369,13 @@ func genFile(outFile, pkg string, unexport bool, toks []structToken) error {
 		data.Visibility = "s"
 	}
 
+	var convertPluralForm = func(val string) string {
+		return inflection.Plural(strings.Title(val))
+	}
+
 	fnMap := template.FuncMap{"title": strings.Title}
-	scansTmpl, err := template.New("scans").Funcs(fnMap).Parse(scansText)
+	fnMap2 := template.FuncMap{"pluralForm": convertPluralForm}
+	scansTmpl, err := template.New("scans").Funcs(fnMap).Funcs(fnMap2).Parse(scansText)
 	if err != nil {
 		return err
 	}

--- a/tmpl.go
+++ b/tmpl.go
@@ -17,7 +17,7 @@ import "database/sql"
 	return s, nil
 }
 
-func {{$.Visibility}}can{{title .Name}}s(rs *sql.Rows) ([]{{.Name}}, error) {
+func {{$.Visibility}}can{{pluralForm .Name}}(rs *sql.Rows) ([]{{.Name}}, error) {
 	structs := make([]{{.Name}}, 0, 16)
 	var err error
 	for rs.Next() {


### PR DESCRIPTION
I fix convert word logic.
Partial failure with multiple transformation

now
`category -> categorys`

fixed
`category -> categories`